### PR TITLE
Cancel and Fetch CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ func main() {
 	}
 
 	// Create the document fingerprint:
-	if err = tbai.Fingerprint(doc, prev); err != nil {
+	if err = doc.Fingerprint(prev); err != nil {
 		panic(err)
 	}
 
 	// Sign the document:
-	if err := tbai.Sign(doc); err != nil {
+	if err := doc.Sign(); err != nil {
 		panic(err)
 	}
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ func main() {
 	tbai, err := ticketbai.New(soft,
 		ticketbai.WithCertificate(cert), // Use the certificate previously loaded
 		ticketbai.WithSupplierIssuer(),  // The issuer is the invoice's supplier
-		ticketbai.InTesting()            // Use the tax agency testing environment
+		ticketbai.InTesting(),           // Use the tax agency testing environment
 	)
 	if err != nil {
 		panic(err)

--- a/cancel_document.go
+++ b/cancel_document.go
@@ -1,0 +1,105 @@
+package ticketbai
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/invopop/gobl"
+	"github.com/invopop/gobl.ticketbai/internal/doc"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/regimes/es"
+	"github.com/invopop/xmldsig"
+)
+
+// CancelDocument is a wrapper around the internal AnulaTicketBAI document.
+type CancelDocument struct {
+	env  *gobl.Envelope
+	inv  *bill.Invoice
+	zone l10n.Code
+	tbai *doc.AnulaTicketBAI // output
+
+	client *Client
+}
+
+func newCancelDocument(c *Client, env *gobl.Envelope) (*CancelDocument, error) {
+	d := new(CancelDocument)
+
+	// Set the client for later use
+	d.client = c
+
+	// Extract the Invoice
+	var ok bool
+	d.env = env
+	d.inv, ok = d.env.Extract().(*bill.Invoice)
+	if !ok {
+		return nil, ErrOnlyInvoices
+	}
+
+	if d.inv.Supplier.TaxID.Country != l10n.ES {
+		return nil, ErrNotSpanish
+	}
+
+	// Set the zone for later use
+	d.zone = d.inv.Supplier.TaxID.Zone
+	if d.zone == "" {
+		return nil, ErrInvalidZone
+	}
+
+	// Extract the time when the invoice was posted to TicketBAI gateway
+	ts, err := extractPostTime(d.env)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the document
+	d.tbai, err = doc.NewAnulaTicketBAI(d.inv, ts)
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}
+
+// Fingerprint generates a finger print for the TicketBAI document using the
+// data provided from the previous invoice data.
+func (d *CancelDocument) Fingerprint() error {
+	c := d.client // shortcut
+
+	conf := &doc.FingerprintConfig{
+		License:         c.software.License,
+		NIF:             c.software.NIF,
+		SoftwareName:    c.software.Name,
+		SoftwareVersion: c.software.Version,
+	}
+	return d.tbai.Fingerprint(conf)
+}
+
+// Sign is used to generate the XML DSig components of the final XML document.
+func (d *CancelDocument) Sign() error {
+	c := d.client // shortcut
+
+	dID := d.env.Head.UUID.String()
+	if err := d.tbai.Sign(dID, c.cert, c.issuerRole, xmldsig.WithCurrentTime(c.CurrentTime)); err != nil {
+		return fmt.Errorf("signing: %w", err)
+	}
+
+	return nil
+}
+
+func extractPostTime(env *gobl.Envelope) (time.Time, error) {
+	for _, stamp := range env.Head.Stamps {
+		if stamp.Provider == es.StampProviderTBAICode {
+			parts := strings.Split(stamp.Value, "-")
+			ts, err := time.Parse("020106", parts[2])
+			if err != nil {
+				return time.Time{}, fmt.Errorf("parsing previous invoice date: %w", err)
+			}
+
+			return ts, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("missing previous %s stamp in envelope", es.StampProviderTBAICode)
+}

--- a/cmd/gobl.ticketbai/cancel.go
+++ b/cmd/gobl.ticketbai/cancel.go
@@ -1,0 +1,122 @@
+// Package main provides the command line interface to the TicketBAI package.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/invopop/gobl"
+	ticketbai "github.com/invopop/gobl.ticketbai"
+	"github.com/invopop/xmldsig"
+	"github.com/spf13/cobra"
+)
+
+type cancelOpts struct {
+	*rootOpts
+	cert       string
+	password   string
+	swNIF      string
+	swName     string
+	swVersion  string
+	swLicense  string
+	production bool
+}
+
+func cancel(o *rootOpts) *cancelOpts {
+	return &cancelOpts{rootOpts: o}
+}
+
+func (c *cancelOpts) cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cancel [infile]",
+		Short: "Cancels an invoice in the TicketBAI provider",
+		RunE:  c.runE,
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&c.cert, "cert", "", "Certificate for authentication")
+	f.StringVar(&c.password, "password", "", "Password of the certificate")
+	f.StringVar(&c.swNIF, "sw-nif", "", "NIF of the software company")
+	f.StringVar(&c.swName, "sw-name", "", "Name of the software")
+	f.StringVar(&c.swVersion, "sw-version", "", "Version of the software")
+	f.StringVar(&c.swLicense, "sw-license", "", "License of the software")
+	f.BoolVarP(&c.production, "production", "p", false, "Production environment")
+
+	cmd.MarkFlagRequired("cert")             // nolint:errcheck
+	cmd.MarkFlagRequired("password")         // nolint:errcheck
+	cmd.MarkFlagRequired("software-nif")     // nolint:errcheck
+	cmd.MarkFlagRequired("software-name")    // nolint:errcheck
+	cmd.MarkFlagRequired("software-version") // nolint:errcheck
+	cmd.MarkFlagRequired("software-license") // nolint:errcheck
+	cmd.MarkFlagRequired("zone")             // nolint:errcheck
+
+	return cmd
+}
+
+func (c *cancelOpts) runE(cmd *cobra.Command, args []string) error {
+	input, err := openInput(cmd, args)
+	if err != nil {
+		return err
+	}
+	defer input.Close() // nolint:errcheck
+
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(input); err != nil {
+		return fmt.Errorf("reading input: %w", err)
+	}
+
+	env := new(gobl.Envelope)
+	if err := json.Unmarshal(buf.Bytes(), env); err != nil {
+		return fmt.Errorf("unmarshaling gobl envelope: %w", err)
+	}
+
+	soft := &ticketbai.Software{
+		NIF:     c.swNIF,
+		Name:    c.swName,
+		Version: c.swVersion,
+		License: c.swLicense,
+	}
+
+	cert, err := xmldsig.LoadCertificate(c.cert, c.password)
+	if err != nil {
+		panic(err)
+	}
+
+	opts := []ticketbai.Option{
+		ticketbai.WithCertificate(cert),
+		ticketbai.WithThirdPartyIssuer(),
+	}
+
+	if c.production {
+		opts = append(opts, ticketbai.InProduction())
+	} else {
+		opts = append(opts, ticketbai.InTesting())
+	}
+
+	tbai, err := ticketbai.New(soft, opts...)
+	if err != nil {
+		panic(err)
+	}
+
+	doc, err := tbai.NewCancelDocument(env)
+	if err != nil {
+		panic(err)
+	}
+
+	err = doc.Fingerprint()
+	if err != nil {
+		panic(err)
+	}
+
+	if err := doc.Sign(); err != nil {
+		panic(err)
+	}
+
+	err = tbai.Cancel(doc)
+	if err != nil {
+		panic(err)
+	}
+
+	return nil
+}

--- a/cmd/gobl.ticketbai/fetch.go
+++ b/cmd/gobl.ticketbai/fetch.go
@@ -1,0 +1,99 @@
+// Package main provides the command line interface to the TicketBAI package.
+package main
+
+import (
+	ticketbai "github.com/invopop/gobl.ticketbai"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/xmldsig"
+	"github.com/spf13/cobra"
+)
+
+type fetchOpts struct {
+	*rootOpts
+	cert       string
+	password   string
+	zone       string
+	nif        string
+	name       string
+	year       int
+	swNIF      string
+	swName     string
+	swVersion  string
+	swLicense  string
+	production bool
+}
+
+func fetch(o *rootOpts) *fetchOpts {
+	return &fetchOpts{rootOpts: o}
+}
+
+func (c *fetchOpts) cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fetch",
+		Short: "Fetches issued documents from the TicketBAI provider",
+		RunE:  c.runE,
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&c.cert, "cert", "", "Certificate for authentication")
+	f.StringVar(&c.password, "password", "", "Password of the certificate")
+	f.StringVar(&c.nif, "nif", "", "NIF of the taxpayer")
+	f.StringVar(&c.name, "name", "", "Name of the taxpayer")
+	f.IntVar(&c.year, "year", 0, "Year of the invoice")
+	f.StringVarP(&c.zone, "zone", "z", "", "Zone of the documents (BI, AL or GU)")
+	f.StringVar(&c.swNIF, "sw-nif", "", "NIF of the software company")
+	f.StringVar(&c.swName, "sw-name", "", "Name of the software")
+	f.StringVar(&c.swVersion, "sw-version", "", "Version of the software")
+	f.StringVar(&c.swLicense, "sw-license", "", "License of the software")
+	f.BoolVarP(&c.production, "production", "p", false, "Production environment")
+
+	cmd.MarkFlagRequired("cert")             // nolint:errcheck
+	cmd.MarkFlagRequired("password")         // nolint:errcheck
+	cmd.MarkFlagRequired("nif")              // nolint:errcheck
+	cmd.MarkFlagRequired("name")             // nolint:errcheck
+	cmd.MarkFlagRequired("year")             // nolint:errcheck
+	cmd.MarkFlagRequired("software-nif")     // nolint:errcheck
+	cmd.MarkFlagRequired("software-name")    // nolint:errcheck
+	cmd.MarkFlagRequired("software-version") // nolint:errcheck
+	cmd.MarkFlagRequired("software-license") // nolint:errcheck
+	cmd.MarkFlagRequired("zone")             // nolint:errcheck
+
+	return cmd
+}
+
+func (c *fetchOpts) runE(*cobra.Command, []string) error {
+	soft := &ticketbai.Software{
+		NIF:     c.swNIF,
+		Name:    c.swName,
+		Version: c.swVersion,
+		License: c.swLicense,
+	}
+
+	cert, err := xmldsig.LoadCertificate(c.cert, c.password)
+	if err != nil {
+		panic(err)
+	}
+
+	opts := []ticketbai.Option{
+		ticketbai.WithCertificate(cert),
+		ticketbai.WithThirdPartyIssuer(),
+	}
+
+	if c.production {
+		opts = append(opts, ticketbai.InProduction())
+	} else {
+		opts = append(opts, ticketbai.InTesting())
+	}
+
+	tbai, err := ticketbai.New(soft, opts...)
+	if err != nil {
+		panic(err)
+	}
+
+	err = tbai.Fetch(l10n.Code(c.zone), c.nif, c.name, c.year)
+	if err != nil {
+		panic(err)
+	}
+
+	return nil
+}

--- a/cmd/gobl.ticketbai/root.go
+++ b/cmd/gobl.ticketbai/root.go
@@ -23,6 +23,7 @@ func (o *rootOpts) cmd() *cobra.Command {
 
 	cmd.AddCommand(versionCmd())
 	cmd.AddCommand(convert(o).cmd())
+	cmd.AddCommand(fetch(o).cmd())
 
 	return cmd
 }

--- a/cmd/gobl.ticketbai/root.go
+++ b/cmd/gobl.ticketbai/root.go
@@ -24,6 +24,7 @@ func (o *rootOpts) cmd() *cobra.Command {
 	cmd.AddCommand(versionCmd())
 	cmd.AddCommand(convert(o).cmd())
 	cmd.AddCommand(fetch(o).cmd())
+	cmd.AddCommand(cancel(o).cmd())
 
 	return cmd
 }

--- a/document.go
+++ b/document.go
@@ -1,0 +1,139 @@
+package ticketbai
+
+import (
+	"fmt"
+
+	"github.com/invopop/gobl"
+	"github.com/invopop/gobl.ticketbai/internal/doc"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/head"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/regimes/es"
+	"github.com/invopop/xmldsig"
+)
+
+// Document is a wrapper around the internal TicketBAI document.
+type Document struct {
+	env  *gobl.Envelope
+	inv  *bill.Invoice
+	zone l10n.Code
+	tbai *doc.TicketBAI // output
+
+	client *Client
+}
+
+func newDocument(c *Client, env *gobl.Envelope) (*Document, error) {
+	d := new(Document)
+
+	// Set the client for later use
+	d.client = c
+
+	// Extract the Invoice
+	var ok bool
+	d.env = env
+	d.inv, ok = d.env.Extract().(*bill.Invoice)
+	if !ok {
+		return nil, ErrOnlyInvoices
+	}
+
+	// Check the existing stamps, we might not need to do anything
+	if d.hasExistingStamps() {
+		return nil, ErrAlreadyProcessed
+	}
+	if d.inv.Supplier.TaxID.Country != l10n.ES {
+		return nil, ErrNotSpanish
+	}
+	d.zone = d.inv.Supplier.TaxID.Zone
+	if d.zone == "" {
+		return nil, ErrInvalidZone
+	}
+
+	var err error
+	d.tbai, err = doc.NewTicketBAI(d.inv, c.CurrentTime(), c.issuerRole)
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}
+
+// Fingerprint generates a finger print for the TicketBAI document using the
+// data provided from the previous invoice data. If there was no previous
+// invoice, the parameter should be nil.
+func (d *Document) Fingerprint(prev *PreviousInvoice) error {
+	c := d.client // shortcut
+
+	conf := &doc.FingerprintConfig{
+		License:         c.software.License,
+		NIF:             c.software.NIF,
+		SoftwareName:    c.software.Name,
+		SoftwareVersion: c.software.Version,
+	}
+
+	if prev != nil {
+		conf.LastSeries = prev.Series
+		conf.LastCode = prev.Code
+		conf.LastIssueDate = prev.IssueDate
+		conf.LastSignature = prev.Signature
+	}
+
+	return d.tbai.Fingerprint(conf)
+}
+
+// Sign is used to generate the XML DSig components of the final XML document.
+// This method will also update the GOBL Envelope with the QR codes that are
+// generated.
+func (d *Document) Sign() error {
+	c := d.client // shortcut
+
+	dID := d.env.Head.UUID.String()
+	if err := d.tbai.Sign(dID, c.cert, c.issuerRole, xmldsig.WithCurrentTime(c.CurrentTime)); err != nil {
+		return fmt.Errorf("signing: %w", err)
+	}
+
+	// now generate the QR codes and add them to the envelope
+	codes := d.tbai.QRCodes()
+	d.env.Head.AddStamp(
+		&head.Stamp{
+			Provider: es.StampProviderTBAICode,
+			Value:    codes.TBAICode,
+		},
+	)
+	d.env.Head.AddStamp(
+		&head.Stamp{
+			Provider: es.StampProviderTBAIQR,
+			Value:    codes.QRCode,
+		},
+	)
+
+	return nil
+}
+
+// Bytes generates the byte output of the TicketBAI Document.
+func (d *Document) Bytes() ([]byte, error) {
+	return d.tbai.Bytes()
+}
+
+// BytesIndent generates the indented byte output of the TicketBAI Document.
+func (d *Document) BytesIndent() ([]byte, error) {
+	return d.tbai.BytesIndent()
+}
+
+// Head returns the CabeceraFactura from the TicketBAI document.
+func (d *Document) Head() *doc.CabeceraFactura {
+	return d.tbai.Factura.CabeceraFactura
+}
+
+// SignatureValue provides quick access to the XML signatures final value.
+func (d *Document) SignatureValue() string {
+	return d.tbai.SignatureValue()
+}
+
+func (d *Document) hasExistingStamps() bool {
+	for _, stamp := range d.env.Head.Stamps {
+		if stamp.Provider.In(es.StampProviderTBAICode, es.StampProviderTBAIQR) {
+			return true
+		}
+	}
+	return false
+}

--- a/examples_test.go
+++ b/examples_test.go
@@ -138,7 +138,7 @@ func convertExample(tbai *ticketbai.Client, example string) ([]byte, error) {
 		return nil, err
 	}
 
-	err = tbai.Fingerprint(doc, &ticketbai.PreviousInvoice{
+	err = doc.Fingerprint(&ticketbai.PreviousInvoice{
 		Series:    "AF",
 		Code:      "1234567890",
 		IssueDate: "01-01-2021",
@@ -148,7 +148,7 @@ func convertExample(tbai *ticketbai.Client, example string) ([]byte, error) {
 		return nil, err
 	}
 
-	err = tbai.Sign(doc)
+	err = doc.Sign()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/doc/cancel.go
+++ b/internal/doc/cancel.go
@@ -1,0 +1,86 @@
+package doc
+
+import (
+	"encoding/xml"
+	"time"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/xmldsig"
+)
+
+// AnulaTicketBAI contains the data needed to cancel a TicketBAI invoice
+type AnulaTicketBAI struct {
+	XMLName    xml.Name `xml:"T:AnulaTicketBai"`
+	TNamespace string   `xml:"xmlns:T,attr"`
+
+	Cabecera   *Cabecera
+	IDFactura  *IDFactura
+	HuellaTBAI *HuellaTBAI
+	Signature  *xmldsig.Signature `xml:"ds:Signature,omitempty"`
+
+	zone l10n.Code // copied from invoice
+}
+
+// IDFactura contains the info to identify the invoice to cancel
+type IDFactura struct {
+	Emisor          *Emisor
+	CabeceraFactura *CabeceraAnulacionFactura
+}
+
+// CabeceraAnulacionFactura contains the header of the invoice to cancel
+type CabeceraAnulacionFactura struct {
+	SerieFactura           string `xml:",omitempty"`
+	NumFactura             string
+	FechaExpedicionFactura string
+}
+
+// NewAnulaTicketBAI creates a new AnulaTicketBAI document
+func NewAnulaTicketBAI(inv *bill.Invoice, ts time.Time) (*AnulaTicketBAI, error) {
+	doc := &AnulaTicketBAI{
+		TNamespace: ticketBAIAnulacionNamespace,
+		Cabecera: &Cabecera{
+			IDVersionTBAI: ticketBAIVersion,
+		},
+		IDFactura: &IDFactura{
+			Emisor: newEmisor(inv.Supplier),
+			CabeceraFactura: &CabeceraAnulacionFactura{
+				SerieFactura:           inv.Series,
+				NumFactura:             inv.Code,
+				FechaExpedicionFactura: ts.In(location).Format("02-01-2006"),
+			},
+		},
+	}
+
+	doc.zone = inv.Supplier.TaxID.Zone
+
+	return doc, nil
+}
+
+// Fingerprint calculates the fingerprint of the document
+func (doc *AnulaTicketBAI) Fingerprint(conf *FingerprintConfig) error {
+	doc.HuellaTBAI = newHuellaTBAI(conf)
+	return nil
+}
+
+// Sign signs the document with the given certificate and role
+func (doc *AnulaTicketBAI) Sign(docID string, cert *xmldsig.Certificate, role IssuerRole, opts ...xmldsig.Option) error {
+	s, err := newSignature(doc, docID, doc.zone, role, cert, opts...)
+	if err != nil {
+		return err
+	}
+
+	doc.Signature = s
+
+	return nil
+}
+
+// Bytes returns the XML document bytes
+func (doc *AnulaTicketBAI) Bytes() ([]byte, error) {
+	return toBytes(doc)
+}
+
+// BytesIndent returns the indented XML document bytes
+func (doc *AnulaTicketBAI) BytesIndent() ([]byte, error) {
+	return toBytes(doc)
+}

--- a/internal/doc/fingerprint.go
+++ b/internal/doc/fingerprint.go
@@ -41,8 +41,8 @@ type EntidadDesarrolladora struct {
 	NIF string
 }
 
-func (doc *TicketBAI) buildHuellaTBAI(conf *FingerprintConfig) error {
-	doc.HuellaTBAI = &HuellaTBAI{
+func newHuellaTBAI(conf *FingerprintConfig) *HuellaTBAI {
+	huella := &HuellaTBAI{
 		EncadenamientoFacturaAnterior: nil,
 		Software: &Software{
 			LicenciaTBAI: conf.License,
@@ -55,7 +55,7 @@ func (doc *TicketBAI) buildHuellaTBAI(conf *FingerprintConfig) error {
 	}
 
 	if conf.LastCode != "" {
-		doc.HuellaTBAI.EncadenamientoFacturaAnterior = &EncadenamientoFacturaAnterior{
+		huella.EncadenamientoFacturaAnterior = &EncadenamientoFacturaAnterior{
 			SerieFacturaAnterior:               conf.LastSeries,
 			NumFacturaAnterior:                 conf.LastCode,
 			FechaExpedicionFacturaAnterior:     conf.LastIssueDate,
@@ -63,7 +63,7 @@ func (doc *TicketBAI) buildHuellaTBAI(conf *FingerprintConfig) error {
 		}
 	}
 
-	return nil
+	return huella
 }
 
 func trunc(s string, n int) string {

--- a/internal/doc/qr_code_test.go
+++ b/internal/doc/qr_code_test.go
@@ -39,7 +39,7 @@ func TestQRCodes(t *testing.T) {
 		err = invoice.Fingerprint(conf)
 		require.NoError(t, err)
 
-		err = invoice.Sign("TEST", cert, xmldsig.WithCurrentTime(func() time.Time {
+		err = invoice.Sign("TEST", cert, role, xmldsig.WithCurrentTime(func() time.Time {
 			// Make sure same time is always returned so signature values are
 			// always the same
 			return ts

--- a/internal/doc/signatures_test.go
+++ b/internal/doc/signatures_test.go
@@ -24,7 +24,7 @@ func TestSignatureGeneration(t *testing.T) {
 		goblInvoice, _ := test.LoadInvoice("sample-invoice.json")
 		invoice, _ := doc.NewTicketBAI(goblInvoice, ts, role)
 
-		err := invoice.Sign("TEST", cert)
+		err := invoice.Sign("TEST", cert, role)
 		require.NoError(t, err)
 
 		assert.Equal(t,

--- a/internal/gateways/ebizkaia/ebizkaia.go
+++ b/internal/gateways/ebizkaia/ebizkaia.go
@@ -16,11 +16,12 @@ import (
 
 // Constants used in headers
 const (
-	concepto           = "LROE"
-	apartado1          = "1"
-	apartado1_1        = "1.1"
-	modelo240          = "240"
-	schemaLROE240ConSG = "https://www.batuz.eus/fitxategiak/batuz/LROE/esquemas/LROE_PJ_240_1_1_FacturasEmitidas_ConSG_AltaPeticion_V1_0_2.xsd"
+	concepto                   = "LROE"
+	apartado1                  = "1"
+	apartado1_1                = "1.1"
+	modelo240                  = "240"
+	schemaLROE240ConSGAlta     = "https://www.batuz.eus/fitxategiak/batuz/LROE/esquemas/LROE_PJ_240_1_1_FacturasEmitidas_ConSG_AltaPeticion_V1_0_2.xsd"
+	schemaLROE240ConSGConsulta = "https://www.batuz.eus/fitxategiak/batuz/LROE/esquemas/LROE_PJ_240_1_1_FacturasEmitidas_ConSG_ConsultaPeticion_V1_0_0.xsd"
 )
 
 const (
@@ -32,10 +33,10 @@ const (
 	operacionEnumConsulta                       = "C00"
 )
 
-// CreateRequest tries to keep all the request information in one place ready to send to the
+// Request tries to keep all the request information in one place ready to send to the
 // Bizkaia servers. They really out did themselves while defining these connections making it
 // increadibly complex.
-type CreateRequest struct {
+type Request struct {
 	Header  []byte // JSON special data header
 	Payload []byte // already gzipped
 }
@@ -78,6 +79,15 @@ type LROEPJ240FacturasEmitidasConSGAltaPeticion struct {
 	FacturasEmitidas *FacturasEmitidasConSGCodificadoType
 }
 
+// LROEPJ240FacturasEmitidasConSGConsultaPeticion is used for querying invoices.
+type LROEPJ240FacturasEmitidasConSGConsultaPeticion struct {
+	XMLName       xml.Name `xml:"lrpjfecsgcp:LROEPJ240FacturasEmitidasConSGConsultaPeticion"`
+	LROENamespace string   `xml:"xmlns:lrpjfecsgcp,attr"`
+
+	Cabecera                            *Cabecera240Type
+	FiltroConsultaFacturasEmitidasConSG *FiltroConsultaFacturasEmitidasConSGType
+}
+
 // Cabecera240Type contains the operation headers
 type Cabecera240Type struct {
 	Modelo             string
@@ -93,6 +103,11 @@ type Cabecera240Type struct {
 // to send.
 type FacturasEmitidasConSGCodificadoType struct {
 	FacturaEmitida []*DetalleEmitidaConSGCodificadoType // max length 1000
+}
+
+// FiltroConsultaFacturasEmitidasConSGType contains the details of a invoice query.
+type FiltroConsultaFacturasEmitidasConSGType struct {
+	NumPaginaConsulta int
 }
 
 // DetalleEmitidaConSGCodificadoType contains the invoice to upload
@@ -117,17 +132,61 @@ type Supplier struct {
 
 // NewCreateRequest simplifies the process of creating a new request for a regular
 // company using Invopop.
-func NewCreateRequest(sup *Supplier, payload []byte) (*CreateRequest, error) {
-	req := new(CreateRequest)
-
-	head := newCabecera240Type(sup)
-	facs := newFacturasEmitidas(payload)
-
+func NewCreateRequest(sup *Supplier, payload []byte) (*Request, error) {
 	body := &LROEPJ240FacturasEmitidasConSGAltaPeticion{
-		LROENamespace:    schemaLROE240ConSG,
-		Cabecera:         head,
-		FacturasEmitidas: facs,
+		LROENamespace:    schemaLROE240ConSGAlta,
+		Cabecera:         newCabecera240Type(sup, operacionEnumAlta),
+		FacturasEmitidas: newFacturasEmitidas(payload),
 	}
+
+	return newRequest(sup, body)
+}
+
+// NewFetchRequest assembles a new Fetch request
+func NewFetchRequest(sup *Supplier) (*Request, error) {
+	body := &LROEPJ240FacturasEmitidasConSGConsultaPeticion{
+		LROENamespace: schemaLROE240ConSGConsulta,
+		Cabecera:      newCabecera240Type(sup, operacionEnumConsulta),
+		FiltroConsultaFacturasEmitidasConSG: &FiltroConsultaFacturasEmitidasConSGType{
+			NumPaginaConsulta: 1,
+		},
+	}
+
+	return newRequest(sup, body)
+}
+
+// newFacturasEmitidas will encode the invoice data to base64 and instantiate a
+// new object to include in the XML message body.
+func newFacturasEmitidas(payloads ...[]byte) *FacturasEmitidasConSGCodificadoType {
+	b := &FacturasEmitidasConSGCodificadoType{
+		FacturaEmitida: make([]*DetalleEmitidaConSGCodificadoType, len(payloads)),
+	}
+	for i, d := range payloads {
+		b.FacturaEmitida[i] = &DetalleEmitidaConSGCodificadoType{
+			TicketBai: base64.StdEncoding.EncodeToString(d),
+		}
+	}
+	return b
+}
+
+func newCabecera240Type(sup *Supplier, op string) *Cabecera240Type {
+	head := &Cabecera240Type{
+		Modelo:      modelo240,
+		Capitulo:    apartado1, // nolint:misspell
+		Subcapitulo: apartado1_1,
+		Operacion:   op,
+		Version:     "1.0",
+		Ejercicio:   fmt.Sprintf("%d", sup.Year),
+		ObligadoTributario: &NIFPersonaType{
+			NIF:                        sup.NIF,
+			ApellidosNombreRazonSocial: sup.Name,
+		},
+	}
+	return head
+}
+
+func newRequest(sup *Supplier, body any) (*Request, error) {
+	req := new(Request)
 
 	bdata, err := xml.Marshal(body)
 	if err != nil {
@@ -145,38 +204,7 @@ func NewCreateRequest(sup *Supplier, payload []byte) (*CreateRequest, error) {
 		return nil, fmt.Errorf("json header: %w", err)
 	}
 
-	// Holy fuck that was complicated.
 	return req, nil
-}
-
-// newFacturasEmitidas will encode the invoice data to base64 and instantiate a
-// new object to include in the XML message body.
-func newFacturasEmitidas(payloads ...[]byte) *FacturasEmitidasConSGCodificadoType {
-	b := &FacturasEmitidasConSGCodificadoType{
-		FacturaEmitida: make([]*DetalleEmitidaConSGCodificadoType, len(payloads)),
-	}
-	for i, d := range payloads {
-		b.FacturaEmitida[i] = &DetalleEmitidaConSGCodificadoType{
-			TicketBai: base64.StdEncoding.EncodeToString(d),
-		}
-	}
-	return b
-}
-
-func newCabecera240Type(sup *Supplier) *Cabecera240Type {
-	head := &Cabecera240Type{
-		Modelo:      modelo240,
-		Capitulo:    apartado1, // nolint:misspell
-		Subcapitulo: apartado1_1,
-		Operacion:   operacionEnumAlta,
-		Version:     "1.0",
-		Ejercicio:   fmt.Sprintf("%d", sup.Year),
-		ObligadoTributario: &NIFPersonaType{
-			NIF:                        sup.NIF,
-			ApellidosNombreRazonSocial: sup.Name,
-		},
-	}
-	return head
 }
 
 func newN3Header(sup *Supplier) *N3Header {

--- a/internal/gateways/gateways.go
+++ b/internal/gateways/gateways.go
@@ -35,6 +35,7 @@ type Connection interface {
 	// Post sends the complete TicketBAI document to the remote end-point. We assume
 	// the document has been fully prepared and signed.
 	Post(inv *bill.Invoice, payload []byte) error
+	Fetch(nif string, name string, year int) error
 }
 
 // List keeps together the list of connections

--- a/internal/gateways/gateways.go
+++ b/internal/gateways/gateways.go
@@ -11,10 +11,13 @@ import (
 	"github.com/invopop/xmldsig"
 )
 
+// Environment defines the environment to use for connections
+type Environment string
+
 // Environment to use for connections
 const (
-	EnvProduction = "production"
-	EnvTesting    = "testing"
+	EnvironmentProduction Environment = "production"
+	EnvironmentTesting    Environment = "testing"
 )
 
 // Error is used to provide more contextual errors
@@ -36,6 +39,7 @@ type Connection interface {
 	// the document has been fully prepared and signed.
 	Post(inv *bill.Invoice, payload []byte) error
 	Fetch(nif string, name string, year int) error
+	Cancel(inv *bill.Invoice, payload []byte) error
 }
 
 // List keeps together the list of connections
@@ -44,7 +48,7 @@ type List struct {
 }
 
 // New instantiates a new set of connections using the provided config.
-func New(env string, cert *xmldsig.Certificate) (*List, error) {
+func New(env Environment, cert *xmldsig.Certificate) (*List, error) {
 	l := new(List)
 
 	tlsConf, err := cert.TLSAuthConfig()

--- a/ticketbai.go
+++ b/ticketbai.go
@@ -209,6 +209,16 @@ func (c *Client) Post(d *Document) error {
 	return conn.Post(d.inv, p)
 }
 
+// Fetch will retrieve the issued documents from the TicketBAI gateway.
+func (c *Client) Fetch(zone l10n.Code, nif string, name string, year int) error {
+	conn := c.list.For(zone)
+	if conn == nil {
+		return fmt.Errorf("no gateway available for %s", zone)
+	}
+
+	return conn.Fetch(nif, name, year)
+}
+
 // Fingerprint generates a finger print for the TicketBAI document using the
 // data provided from the previous invoice data. If there was no previous
 // invoice, the parameter should be nil.

--- a/ticketbai.go
+++ b/ticketbai.go
@@ -10,10 +10,7 @@ import (
 	"github.com/invopop/gobl"
 	"github.com/invopop/gobl.ticketbai/internal/doc"
 	"github.com/invopop/gobl.ticketbai/internal/gateways"
-	"github.com/invopop/gobl/bill"
-	"github.com/invopop/gobl/head"
 	"github.com/invopop/gobl/l10n"
-	"github.com/invopop/gobl/regimes/es"
 	"github.com/invopop/xmldsig"
 )
 
@@ -30,8 +27,8 @@ type Client struct {
 	software   *Software
 	list       *gateways.List
 	cert       *xmldsig.Certificate
-	env        string
-	issuerRole string
+	env        gateways.Environment
+	issuerRole doc.IssuerRole
 	curTime    time.Time
 }
 
@@ -94,14 +91,14 @@ func WithThirdPartyIssuer() Option {
 // InProduction defines the connection to use the production environment.
 func InProduction() Option {
 	return func(c *Client) {
-		c.env = gateways.EnvProduction
+		c.env = gateways.EnvironmentProduction
 	}
 }
 
 // InTesting defines the connection to use the testing environment.
 func InTesting() Option {
 	return func(c *Client) {
-		c.env = gateways.EnvTesting
+		c.env = gateways.EnvironmentTesting
 	}
 }
 
@@ -125,14 +122,6 @@ type PreviousInvoice struct {
 	Signature string
 }
 
-// Document is a wrapper around the internal TicketBAI document.
-type Document struct {
-	env  *gobl.Envelope
-	inv  *bill.Invoice
-	zone l10n.Code
-	tbai *doc.TicketBAI // output
-}
-
 // New creates a new TicketBAI client with shared software and configuration
 // options for creating and sending new documents.
 func New(software *Software, opts ...Option) (*Client, error) {
@@ -140,7 +129,7 @@ func New(software *Software, opts ...Option) (*Client, error) {
 	c.software = software
 
 	// Set default values that can be overwritten by the options
-	c.env = gateways.EnvTesting
+	c.env = gateways.EnvironmentTesting
 	c.issuerRole = doc.IssuerRoleSupplier
 
 	for _, opt := range opts {
@@ -163,35 +152,13 @@ func New(software *Software, opts ...Option) (*Client, error) {
 // NewDocument creates a new TicketBAI document from the provided GOBL Envelope.
 // The envelope must contain a valid Invoice.
 func (c *Client) NewDocument(env *gobl.Envelope) (*Document, error) {
-	d := new(Document)
+	return newDocument(c, env)
+}
 
-	// Extract the Invoice
-	var ok bool
-	d.env = env
-	d.inv, ok = d.env.Extract().(*bill.Invoice)
-	if !ok {
-		return nil, ErrOnlyInvoices
-	}
-
-	// Check the existing stamps, we might not need to do anything
-	if d.hasExistingStamps() {
-		return nil, ErrAlreadyProcessed
-	}
-	if d.inv.Supplier.TaxID.Country != l10n.ES {
-		return nil, ErrNotSpanish
-	}
-	d.zone = d.inv.Supplier.TaxID.Zone
-	if d.zone == "" {
-		return nil, ErrInvalidZone
-	}
-
-	var err error
-	d.tbai, err = doc.NewTicketBAI(d.inv, c.CurrentTime(), c.issuerRole)
-	if err != nil {
-		return nil, err
-	}
-
-	return d, nil
+// NewCancelDocument creates a new AnulaTicketBAI document from the provided
+// GOBL Envelope.
+func (c *Client) NewCancelDocument(env *gobl.Envelope) (*CancelDocument, error) {
+	return newCancelDocument(c, env)
 }
 
 // Post will send the document to the TicketBAI gateway.
@@ -219,50 +186,19 @@ func (c *Client) Fetch(zone l10n.Code, nif string, name string, year int) error 
 	return conn.Fetch(nif, name, year)
 }
 
-// Fingerprint generates a finger print for the TicketBAI document using the
-// data provided from the previous invoice data. If there was no previous
-// invoice, the parameter should be nil.
-func (c *Client) Fingerprint(d *Document, prev *PreviousInvoice) error {
-	conf := &doc.FingerprintConfig{
-		License:         c.software.License,
-		NIF:             c.software.NIF,
-		SoftwareName:    c.software.Name,
-		SoftwareVersion: c.software.Version,
-	}
-	if prev != nil {
-		conf.LastSeries = prev.Series
-		conf.LastCode = prev.Code
-		conf.LastIssueDate = prev.IssueDate
-		conf.LastSignature = prev.Signature
-	}
-	return d.tbai.Fingerprint(conf)
-}
-
-// Sign is used to generate the XML DSig components of the final XML document.
-// This method will also update the GOBL Envelope with the QR codes that are
-// generated.
-func (c *Client) Sign(d *Document) error {
-	dID := d.env.Head.UUID.String()
-	if err := d.tbai.Sign(dID, c.cert, xmldsig.WithCurrentTime(c.CurrentTime)); err != nil {
-		return fmt.Errorf("signing: %w", err)
+// Cancel will send the cancel document in the TicketBAI gateway.
+func (c *Client) Cancel(d *CancelDocument) error {
+	conn := c.list.For(d.zone)
+	if conn == nil {
+		return fmt.Errorf("no gateway available for %s", d.zone)
 	}
 
-	// now generate the QR codes and add them to the envelope
-	codes := d.tbai.QRCodes()
-	d.env.Head.AddStamp(
-		&head.Stamp{
-			Provider: es.StampProviderTBAICode,
-			Value:    codes.TBAICode,
-		},
-	)
-	d.env.Head.AddStamp(
-		&head.Stamp{
-			Provider: es.StampProviderTBAIQR,
-			Value:    codes.QRCode,
-		},
-	)
+	p, err := d.tbai.Bytes()
+	if err != nil {
+		return fmt.Errorf("generating payload: %w", err)
+	}
 
-	return nil
+	return conn.Cancel(d.inv, p)
 }
 
 // CurrentTime returns the current time to use when generating
@@ -272,33 +208,4 @@ func (c *Client) CurrentTime() time.Time {
 		return c.curTime
 	}
 	return time.Now()
-}
-
-// Bytes generates the byte output of the TicketBAI Document.
-func (d *Document) Bytes() ([]byte, error) {
-	return d.tbai.Bytes()
-}
-
-// BytesIndent generates the indented byte output of the TicketBAI Document.
-func (d *Document) BytesIndent() ([]byte, error) {
-	return d.tbai.BytesIndent()
-}
-
-// Head returns the CabeceraFactura from the TicketBAI document.
-func (d *Document) Head() *doc.CabeceraFactura {
-	return d.tbai.Factura.CabeceraFactura
-}
-
-// SignatureValue provides quick access to the XML signatures final value.
-func (d *Document) SignatureValue() string {
-	return d.tbai.SignatureValue()
-}
-
-func (d *Document) hasExistingStamps() bool {
-	for _, stamp := range d.env.Head.Stamps {
-		if stamp.Provider.In(es.StampProviderTBAICode, es.StampProviderTBAIQR) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
* This PR adds CLI commands to query the TicketBAI provider for the posted invoices of a supplier and for cancelling previous invoice postings.
* It includes a semi-large refactoring to avoid duplication between the Cancel and Post operations. We probably can improve it in the future if time allows, but this is a start.