### PR TITLE
Idempotent post to TBAI gateway

### DIFF
--- a/cmd/gobl.ticketbai/fetch.go
+++ b/cmd/gobl.ticketbai/fetch.go
@@ -90,7 +90,7 @@ func (c *fetchOpts) runE(*cobra.Command, []string) error {
 		panic(err)
 	}
 
-	err = tbai.Fetch(l10n.Code(c.zone), c.nif, c.name, c.year)
+	_, err = tbai.Fetch(l10n.Code(c.zone), c.nif, c.name, c.year)
 	if err != nil {
 		panic(err)
 	}

--- a/document.go
+++ b/document.go
@@ -2,6 +2,7 @@ package ticketbai
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/invopop/gobl"
 	"github.com/invopop/gobl.ticketbai/internal/doc"
@@ -87,7 +88,7 @@ func (d *Document) Sign() error {
 	c := d.client // shortcut
 
 	dID := d.env.Head.UUID.String()
-	if err := d.tbai.Sign(dID, c.cert, c.issuerRole, xmldsig.WithCurrentTime(c.CurrentTime)); err != nil {
+	if err := d.tbai.Sign(dID, c.cert, c.issuerRole, xmldsig.WithCurrentTime(d.tbai.IssueTimestamp)); err != nil {
 		return fmt.Errorf("signing: %w", err)
 	}
 
@@ -107,6 +108,11 @@ func (d *Document) Sign() error {
 	)
 
 	return nil
+}
+
+// SetIssueTimestamp updates the issue date and time of the TicketBAI document.
+func (d *Document) SetIssueTimestamp(ts time.Time) {
+	d.tbai.SetIssueTimestamp(ts)
 }
 
 // Bytes generates the byte output of the TicketBAI Document.

--- a/internal/doc/invoice.go
+++ b/internal/doc/invoice.go
@@ -2,7 +2,6 @@ package doc
 
 import (
 	"errors"
-	"time"
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
@@ -49,23 +48,16 @@ type IDClave struct {
 	ClaveRegimenIvaOpTrascendencia string
 }
 
-func newCabeceraFactura(inv *bill.Invoice, ts time.Time) *CabeceraFactura {
+func newCabeceraFactura(inv *bill.Invoice) *CabeceraFactura {
 	simplifiedInvoice := "N"
 	if inv.Tax.ContainsTag(tax.TagSimplified) {
 		simplifiedInvoice = "S"
 	}
 
-	// make sure TZ is correct
-	ts = ts.In(location)
-	issueDate := ts.Format("02-01-2006")
-	issueTime := ts.Format("15:04:05")
-
 	return &CabeceraFactura{
-		SerieFactura:           inv.Series,
-		NumFactura:             inv.Code,
-		FechaExpedicionFactura: issueDate,
-		HoraExpedicionFactura:  issueTime,
-		FacturaSimplificada:    simplifiedInvoice,
+		SerieFactura:        inv.Series,
+		NumFactura:          inv.Code,
+		FacturaSimplificada: simplifiedInvoice,
 	}
 }
 

--- a/internal/gateways/ebizkaia.go
+++ b/internal/gateways/ebizkaia.go
@@ -2,11 +2,14 @@ package gateways
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/invopop/gobl.ticketbai/internal/doc"
 	"github.com/invopop/gobl.ticketbai/internal/gateways/ebizkaia"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/xmldsig"
 	"golang.org/x/net/html/charset"
 )
 
@@ -26,8 +29,9 @@ const (
 	eBizkaiaN3RespCodeHeader  = "Eus-Bizkaia-N3-Codigo-Respuesta"
 	eBizkaiaN3RegNumberHeader = "Eus-Bizkaia-N3-Numero-Registro"
 
-	eBizkaiaN3ResponseInvalid   = "Incorrecto"
-	eBizkaiaN3RespCodeTechnical = "B4_1000004"
+	eBizkaiaN3ResponseInvalid    = "Incorrecto"
+	eBizkaiaN3RespCodeTechnical  = "B4_1000004"
+	eBizkaiaN3RespCodeDuplicated = "B4_2000003"
 )
 
 // EBizkaiaConn keeps all the connection details together for the Vizcaya region.
@@ -56,56 +60,83 @@ func newEbizkaia(env Environment, tlsConfig *tls.Config) *EBizkaiaConn {
 
 // Post sends the complete TicketBAI document to the remote end-point. We assume
 // the document has been signed and prepared.
-func (c *EBizkaiaConn) Post(inv *bill.Invoice, payload []byte) error {
+func (c *EBizkaiaConn) Post(inv *bill.Invoice, doc *doc.TicketBAI) error {
+	payload, err := doc.Bytes()
+	if err != nil {
+		return fmt.Errorf("generating payload: %w", err)
+	}
+
 	sup := &ebizkaia.Supplier{
 		Year: inv.IssueDate.Year,
 		NIF:  inv.Supplier.TaxID.Code.String(),
 		Name: inv.Supplier.Name,
 	}
 
-	doc, err := ebizkaia.NewCreateRequest(sup, payload)
+	req, err := ebizkaia.NewCreateRequest(sup, payload)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
 
-	return c.sendRequest(doc, eBizkaiaExecutePath)
+	resp := ebizkaia.LROEPJ240FacturasEmitidasConSGAltaRespuesta{}
+
+	err = c.sendRequest(req, eBizkaiaExecutePath, &resp)
+	if errors.Is(err, ErrInvalidRequest) && resp.FirstErrorCode() == eBizkaiaN3RespCodeDuplicated {
+		return ErrDuplicatedRecord
+	}
+
+	return err
 }
 
 // Fetch retrieves the TicketBAI from the remote end-point for the given
 // taxpayer and year.
-func (c *EBizkaiaConn) Fetch(nif string, name string, year int) error {
+func (c *EBizkaiaConn) Fetch(nif string, name string, year int, head *doc.CabeceraFactura) ([]*doc.TicketBAI, error) {
 	sup := &ebizkaia.Supplier{
 		Year: year,
 		NIF:  nif,
 		Name: name,
 	}
 
-	doc, err := ebizkaia.NewFetchRequest(sup)
+	d, err := ebizkaia.NewFetchRequest(sup, head)
 	if err != nil {
-		return fmt.Errorf("fetch request: %w", err)
+		return nil, fmt.Errorf("fetch request: %w", err)
 	}
 
-	return c.sendRequest(doc, eBizkaiaQueryPath)
+	resp := ebizkaia.LROEPJ240FacturasEmitidasConSGConsultaRespuesta{}
+	if err := c.sendRequest(d, eBizkaiaQueryPath, &resp); err != nil {
+		return nil, fmt.Errorf("sending fetch request: %w", err)
+	}
+
+	tbais := make([]*doc.TicketBAI, len(resp.FacturasEmitidas.FacturaEmitida))
+	for i, f := range resp.FacturasEmitidas.FacturaEmitida {
+		tbais[i] = buildTBAIDoc(f.TicketBai)
+	}
+
+	return tbais, nil
 }
 
 // Cancel sends the cancellation request for the TickeBAI invoice to the remote
 // end-point.
-func (c *EBizkaiaConn) Cancel(inv *bill.Invoice, payload []byte) error {
+func (c *EBizkaiaConn) Cancel(inv *bill.Invoice, doc *doc.AnulaTicketBAI) error {
+	payload, err := doc.Bytes()
+	if err != nil {
+		return fmt.Errorf("generating payload: %w", err)
+	}
+
 	sup := &ebizkaia.Supplier{
 		Year: inv.IssueDate.Year,
 		NIF:  inv.Supplier.TaxID.Code.String(),
 		Name: inv.Supplier.Name,
 	}
 
-	doc, err := ebizkaia.NewCancelRequest(sup, payload)
+	req, err := ebizkaia.NewCancelRequest(sup, payload)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
 
-	return c.sendRequest(doc, eBizkaiaExecutePath)
+	return c.sendRequest(req, eBizkaiaExecutePath, nil)
 }
 
-func (c *EBizkaiaConn) sendRequest(doc *ebizkaia.Request, path string) error {
+func (c *EBizkaiaConn) sendRequest(doc *ebizkaia.Request, path string, resp interface{}) error {
 	r := c.client.R().
 		SetHeader("Content-Encoding", "gzip").
 		SetHeader("Content-Type", "application/octet-stream").
@@ -114,7 +145,8 @@ func (c *EBizkaiaConn) sendRequest(doc *ebizkaia.Request, path string) error {
 		SetHeaderVerbatim(eBizkaiaN3ContentTypeHeader, "application/xml").
 		SetHeaderVerbatim(eBizkaiaN3DataHeader, string(doc.Header)).
 		SetHeaderVerbatim(eBizkaiaN3VersionHeader, "1.0").
-		SetBody(doc.Payload)
+		SetBody(doc.Payload).
+		SetResult(resp)
 
 	res, err := r.Post(path)
 	if err != nil {
@@ -148,4 +180,19 @@ func convertToUTF8(s string) string {
 	e, _, _ := charset.DetermineEncoding([]byte(s), "")
 	out, _ := e.NewDecoder().Bytes([]byte(s))
 	return string(out)
+}
+
+// buildTBAIDoc builds a doc.TicketBAI from a TicketBAIType.
+func buildTBAIDoc(f *ebizkaia.TicketBaiType) *doc.TicketBAI {
+	return &doc.TicketBAI{
+		Cabecera:   f.Cabecera,
+		Sujetos:    f.Sujetos,
+		Factura:    f.Factura,
+		HuellaTBAI: f.HuellaTBAI,
+		Signature: &xmldsig.Signature{
+			Value: &xmldsig.Value{
+				Value: f.Signature,
+			},
+		},
+	}
 }

--- a/internal/gateways/ebizkaia/ebizkaia.go
+++ b/internal/gateways/ebizkaia/ebizkaia.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+
+	"github.com/invopop/gobl.ticketbai/internal/doc"
 )
 
 // Bizkaia has extra complications when sending documents, so we define all the additional
@@ -68,36 +70,6 @@ type N3DatosRelevantes struct {
 	Ejercicio string `json:"ejer"` // invoice issue year
 }
 
-// LROEPJ240FacturasEmitidasConSGAltaPeticion is used for uploading invoices. "240" refers to
-// the type of entity which in this case is a "business", and "ConSG" means the request is
-// from a "software garante", i.e. Invopop.
-type LROEPJ240FacturasEmitidasConSGAltaPeticion struct {
-	// XMLName xml.Name `xml:"LROEPJ240FacturasEmitidasConSGAltaPeticion"`
-	XMLName       xml.Name `xml:"lrpjfecsgap:LROEPJ240FacturasEmitidasConSGAltaPeticion"`
-	LROENamespace string   `xml:"xmlns:lrpjfecsgap,attr"`
-
-	Cabecera         *Cabecera240Type
-	FacturasEmitidas *FacturasEmitidasConSGCodificadoType
-}
-
-// LROEPJ240FacturasEmitidasConSGConsultaPeticion is used for querying invoices.
-type LROEPJ240FacturasEmitidasConSGConsultaPeticion struct {
-	XMLName       xml.Name `xml:"lrpjfecsgcp:LROEPJ240FacturasEmitidasConSGConsultaPeticion"`
-	LROENamespace string   `xml:"xmlns:lrpjfecsgcp,attr"`
-
-	Cabecera                            *Cabecera240Type
-	FiltroConsultaFacturasEmitidasConSG *FiltroConsultaFacturasEmitidasType
-}
-
-// LROEPJ240FacturasEmitidasConSGAnulacionPeticion is used for cancelling invoices.
-type LROEPJ240FacturasEmitidasConSGAnulacionPeticion struct {
-	XMLName       xml.Name `xml:"lrpjfecsgap:LROEPJ240FacturasEmitidasConSGAnulacionPeticion"`
-	LROENamespace string   `xml:"xmlns:lrpjfecsgap,attr"`
-
-	Cabecera         *Cabecera240Type
-	FacturasEmitidas *AnulacionesFacturasEmitidasConSGType
-}
-
 // Cabecera240Type contains the operation headers
 type Cabecera240Type struct {
 	Modelo             string
@@ -109,15 +81,105 @@ type Cabecera240Type struct {
 	ObligadoTributario *NIFPersonaType
 }
 
+// LROEPJ240FacturasEmitidasConSGAltaPeticion is used for uploading invoices. "240" refers to
+// the type of entity which in this case is a "business", and "ConSG" means the request is
+// from a "software garante", i.e. Invopop.
+type LROEPJ240FacturasEmitidasConSGAltaPeticion struct {
+	XMLName       xml.Name `xml:"lrpjfecsgap:LROEPJ240FacturasEmitidasConSGAltaPeticion"`
+	LROENamespace string   `xml:"xmlns:lrpjfecsgap,attr"`
+
+	Cabecera         *Cabecera240Type
+	FacturasEmitidas *FacturasEmitidasConSGCodificadoType
+}
+
+// LROEPJ240FacturasEmitidasConSGAltaRespuesta represents the response from the server
+// when uploading invoices.
+type LROEPJ240FacturasEmitidasConSGAltaRespuesta struct {
+	Registros *RegistrosFacturaConSGType
+}
+
+// RegistrosFacturaConSGType contains the response for all invoices proccessed in a upload request.
+type RegistrosFacturaConSGType struct {
+	Registro []*RegistroFacturaConSGType
+}
+
+// RegistroFacturaConSGType contains the response for a single invoice proccessed in a upload
+// request.
+type RegistroFacturaConSGType struct {
+	SituacionRegistro *SituacionRegistroType
+}
+
+// SituacionRegistroType details about the outcome of uploading a single invoice.
+type SituacionRegistroType struct {
+	CodigoErrorRegistro string
+}
+
+// LROEPJ240FacturasEmitidasConSGConsultaPeticion represents a request to fetch invoices.
+type LROEPJ240FacturasEmitidasConSGConsultaPeticion struct {
+	XMLName       xml.Name `xml:"lrpjfecsgcp:LROEPJ240FacturasEmitidasConSGConsultaPeticion"`
+	LROENamespace string   `xml:"xmlns:lrpjfecsgcp,attr"`
+
+	Cabecera                            *Cabecera240Type
+	FiltroConsultaFacturasEmitidasConSG *FiltroConsultaFacturasEmitidasType
+}
+
+// FiltroConsultaFacturasEmitidasType contains the details of an invoice query.
+type FiltroConsultaFacturasEmitidasType struct {
+	CabeceraFactura   *CabeceraFacturaConsultaType
+	NumPaginaConsulta int
+}
+
+// CabeceraFacturaConsultaType contains the header of an invoice query.
+type CabeceraFacturaConsultaType struct {
+	SerieFactura           string `xml:",omitempty"`
+	NumFactura             string `xml:",omitempty"`
+	FechaExpedicionFactura *FechaDesdeHastaType
+}
+
+// FechaDesdeHastaType represants a date range
+type FechaDesdeHastaType struct {
+	Desde string `xml:",omitempty"`
+	Hasta string `xml:",omitempty"`
+}
+
+// LROEPJ240FacturasEmitidasConSGConsultaRespuesta represents the response from the server
+// when fetching invoices.
+type LROEPJ240FacturasEmitidasConSGConsultaRespuesta struct {
+	FacturasEmitidas *FacturasEmitidasConSGConsultaRespuestaType
+}
+
+// FacturasEmitidasConSGConsultaRespuestaType contains the response for all invoices fetched.
+type FacturasEmitidasConSGConsultaRespuestaType struct {
+	FacturaEmitida []*FacturaEmitidaConSGConsultaRespuestaType
+}
+
+// FacturaEmitidaConSGConsultaRespuestaType contains the response for a single invoice fetched.
+type FacturaEmitidaConSGConsultaRespuestaType struct {
+	TicketBai *TicketBaiType
+}
+
+// TicketBaiType contains the details of a fetched invoice.
+type TicketBaiType struct {
+	Cabecera   *doc.Cabecera
+	Sujetos    *doc.Sujetos
+	Factura    *doc.Factura
+	HuellaTBAI *doc.HuellaTBAI
+	Signature  string
+}
+
+// LROEPJ240FacturasEmitidasConSGAnulacionPeticion is used for cancelling invoices.
+type LROEPJ240FacturasEmitidasConSGAnulacionPeticion struct {
+	XMLName       xml.Name `xml:"lrpjfecsgap:LROEPJ240FacturasEmitidasConSGAnulacionPeticion"`
+	LROENamespace string   `xml:"xmlns:lrpjfecsgap,attr"`
+
+	Cabecera         *Cabecera240Type
+	FacturasEmitidas *AnulacionesFacturasEmitidasConSGType
+}
+
 // FacturasEmitidasConSGCodificadoType holds an array of invoices
 // to send.
 type FacturasEmitidasConSGCodificadoType struct {
 	FacturaEmitida []*DetalleEmitidaConSGCodificadoType // max length 1000
-}
-
-// FiltroConsultaFacturasEmitidasType contains the details of a invoice query.
-type FiltroConsultaFacturasEmitidasType struct {
-	NumPaginaConsulta int
 }
 
 // AnulacionesFacturasEmitidasConSGType holds an array of invoices to cancel.
@@ -168,13 +230,24 @@ func NewCreateRequest(sup *Supplier, payload []byte) (*Request, error) {
 }
 
 // NewFetchRequest assembles a new Fetch request
-func NewFetchRequest(sup *Supplier) (*Request, error) {
+func NewFetchRequest(sup *Supplier, head *doc.CabeceraFactura) (*Request, error) {
 	body := &LROEPJ240FacturasEmitidasConSGConsultaPeticion{
 		LROENamespace: schemaLROE240ConSGConsulta,
 		Cabecera:      newCabecera240Type(sup, operacionEnumConsulta),
 		FiltroConsultaFacturasEmitidasConSG: &FiltroConsultaFacturasEmitidasType{
 			NumPaginaConsulta: 1,
 		},
+	}
+
+	if head != nil {
+		body.FiltroConsultaFacturasEmitidasConSG.CabeceraFactura = &CabeceraFacturaConsultaType{
+			NumFactura:   head.NumFactura,
+			SerieFactura: head.SerieFactura,
+			FechaExpedicionFactura: &FechaDesdeHastaType{
+				Desde: head.FechaExpedicionFactura,
+				Hasta: head.FechaExpedicionFactura,
+			},
+		}
 	}
 
 	return newRequest(sup, body)
@@ -265,4 +338,13 @@ func compressBody(data []byte) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+// FirstErrorCode returns the first error code in the response.
+func (r *LROEPJ240FacturasEmitidasConSGAltaRespuesta) FirstErrorCode() string {
+	if r.Registros == nil || len(r.Registros.Registro) == 0 {
+		return ""
+	}
+
+	return r.Registros.Registro[0].SituacionRegistro.CodigoErrorRegistro
 }

--- a/internal/gateways/gateways.go
+++ b/internal/gateways/gateways.go
@@ -3,6 +3,7 @@
 package gateways
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/invopop/gobl/bill"
@@ -20,18 +21,11 @@ const (
 	EnvironmentTesting    Environment = "testing"
 )
 
-// Error is used to provide more contextual errors
-type Error string
-
 // Standard gateway error responses
 var (
-	ErrConnection Error = "connection"
+	ErrConnection     = errors.New("connection")
+	ErrInvalidRequest = errors.New("invalid request")
 )
-
-// Error provides string form of an error
-func (e Error) Error() string {
-	return string(e)
-}
 
 // Connection defines what is expected from a connection to a gateway.
 type Connection interface {

--- a/internal/gateways/gateways.go
+++ b/internal/gateways/gateways.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/invopop/gobl.ticketbai/internal/doc"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/regimes/es"
@@ -23,17 +24,18 @@ const (
 
 // Standard gateway error responses
 var (
-	ErrConnection     = errors.New("connection")
-	ErrInvalidRequest = errors.New("invalid request")
+	ErrConnection       = errors.New("connection")
+	ErrInvalidRequest   = errors.New("invalid request")
+	ErrDuplicatedRecord = errors.New("duplicated record")
 )
 
 // Connection defines what is expected from a connection to a gateway.
 type Connection interface {
 	// Post sends the complete TicketBAI document to the remote end-point. We assume
 	// the document has been fully prepared and signed.
-	Post(inv *bill.Invoice, payload []byte) error
-	Fetch(nif string, name string, year int) error
-	Cancel(inv *bill.Invoice, payload []byte) error
+	Post(inv *bill.Invoice, doc *doc.TicketBAI) error
+	Fetch(nif string, name string, year int, head *doc.CabeceraFactura) ([]*doc.TicketBAI, error)
+	Cancel(inv *bill.Invoice, doc *doc.AnulaTicketBAI) error
 }
 
 // List keeps together the list of connections

--- a/test_connection.go
+++ b/test_connection.go
@@ -1,0 +1,31 @@
+package ticketbai
+
+import (
+	"github.com/invopop/gobl.ticketbai/internal/doc"
+	"github.com/invopop/gobl/bill"
+)
+
+// TestConnection is a mock gateway connection for testing purposes
+type TestConnection struct {
+	postCalled   bool
+	fetchCalled  bool
+	cancelCalled bool
+}
+
+// Post mocks the Post method of the Connection interface
+func (tc *TestConnection) Post(_ *bill.Invoice, _ *doc.TicketBAI) error {
+	tc.postCalled = true
+	return nil
+}
+
+// Cancel mocks the Cancel method of the Connection interface
+func (tc *TestConnection) Cancel(_ *bill.Invoice, _ *doc.AnulaTicketBAI) error {
+	tc.cancelCalled = true
+	return nil
+}
+
+// Fetch mocks the Fetch method of the Connection interface
+func (tc *TestConnection) Fetch(_ string, _ string, _ int, _ *doc.CabeceraFactura) ([]*doc.TicketBAI, error) {
+	tc.fetchCalled = true
+	return nil, nil
+}


### PR DESCRIPTION
* Implements changes to guarantee idempotency when posting to the TBAI gateway: multiple identical posts will return exactly the same result and won't cause duplicated side-effects.
* Wraps client (a.k.a. request) errors in a dedicated type so that they can be handled properly downstream (for example, by not retrying them)