### PR TITLE
Fix Panic in CLI Convert

### DIFF
--- a/ticketbai.go
+++ b/ticketbai.go
@@ -123,6 +123,10 @@ func New(software *Software, zone l10n.Code, opts ...Option) (*Client, error) {
 		opt(c)
 	}
 
+	if c.cert == nil {
+		return c, nil
+	}
+
 	if c.gw == nil {
 		var err error
 		c.gw, err = gateways.New(c.env, c.zone, c.cert)


### PR DESCRIPTION
The CLI convert function does not add a certificate to the TicketBAI client. This makes sense as it does not send it to TicketBAI and a certificate is not needed. However, when creating the client it attempts to open a gateway connection with no certificate with leads to a panic.

I have added a nil check for the certificate so that if an invoice with no certificate is sent to the client, it doesn't try to open a gateway to the TicketBAI service.