### PR TITLE
Add support to no tax code customer

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,6 +14,8 @@ linters:
     - unparam
     - zerologlint
   settings:
+    goconst:
+      ignore-tests: true
     staticcheck:
       checks:
         - all

--- a/convert/breakdown.go
+++ b/convert/breakdown.go
@@ -105,7 +105,7 @@ func newTipoDesglose(gobl *bill.Invoice) *TipoDesglose {
 
 	desglose := &TipoDesglose{}
 
-	if gobl.Customer == nil || partyTaxCountry(gobl.Customer) == l10n.ES.Tax() {
+	if gobl.Customer == nil || partyCountry(gobl.Customer) == l10n.ES.Tax() {
 		desglose.DesgloseFactura = newDesgloseFactura(taxInfo, catTotal.Rates)
 	} else {
 		goods, services := splitByTBAIProduct(catTotal.Rates)

--- a/convert/breakdown_test.go
+++ b/convert/breakdown_test.go
@@ -57,7 +57,7 @@ func TestDesgloseConversion(t *testing.T) {
 	t.Run("should distinguish goods from services when customer from other country",
 		func(t *testing.T) {
 			goblInvoice := invoiceFromCountry("GB")
-			goblInvoice.Lines[0].Item.Key = "goods"
+			goblInvoice.Lines[0].Item.Key = org.ItemKeyGoods
 			_ = goblInvoice.Calculate()
 
 			invoice, _ := convert.NewTicketBAI(goblInvoice, ts, role, convert.ZoneBI)
@@ -93,7 +93,7 @@ func TestDesgloseConversion(t *testing.T) {
 				},
 				Taxes: tax.Set{
 					&tax.Combo{
-						Category: "VAT",
+						Category: tax.CategoryVAT,
 						Rate:     "standard",
 					},
 				},
@@ -108,7 +108,7 @@ func TestDesgloseConversion(t *testing.T) {
 				},
 				Taxes: tax.Set{
 					&tax.Combo{
-						Category: "VAT",
+						Category: tax.CategoryVAT,
 						Rate:     "standard",
 					},
 				},
@@ -123,7 +123,7 @@ func TestDesgloseConversion(t *testing.T) {
 				},
 				Taxes: tax.Set{
 					&tax.Combo{
-						Category: "VAT",
+						Category: tax.CategoryVAT,
 						Rate:     "reduced",
 					},
 				},
@@ -152,7 +152,7 @@ func TestDesgloseConversion(t *testing.T) {
 					Index:    1,
 					Quantity: num.MakeAmount(1, 0),
 					Item:     &org.Item{Name: "A", Price: num.NewAmount(10, 0)},
-					Taxes:    tax.Set{&tax.Combo{Category: "VAT", Rate: "standard"}},
+					Taxes:    tax.Set{&tax.Combo{Category: tax.CategoryVAT, Rate: "standard"}},
 				},
 				{
 					Index:    2,
@@ -164,7 +164,7 @@ func TestDesgloseConversion(t *testing.T) {
 					},
 					Taxes: tax.Set{
 						&tax.Combo{
-							Category: "VAT",
+							Category: tax.CategoryVAT,
 							Rate:     "standard",
 						},
 					},
@@ -192,9 +192,9 @@ func TestDesgloseConversion(t *testing.T) {
 			},
 			Discounts: []*bill.LineDiscount{DiscountOf(100)},
 			Taxes: tax.Set{
-				&tax.Combo{Category: "IRPF", Rate: "pro"},
+				&tax.Combo{Category: es.TaxCategoryIRPF, Rate: "pro"},
 				&tax.Combo{
-					Category: "VAT",
+					Category: tax.CategoryVAT,
 					Ext: tax.Extensions{
 						tbai.ExtKeyExempt: "OT",
 					},
@@ -218,7 +218,7 @@ func TestDesgloseConversion(t *testing.T) {
 			Item:     &org.Item{Name: "A", Price: num.NewAmount(10, 0)},
 			Taxes: tax.Set{
 				&tax.Combo{
-					Category: "VAT",
+					Category: tax.CategoryVAT,
 					Ext:      tax.Extensions{tbai.ExtKeyExempt: "RL"},
 				},
 			},
@@ -240,7 +240,7 @@ func TestDesgloseConversion(t *testing.T) {
 			Discounts: []*bill.LineDiscount{DiscountOf(100)},
 			Taxes: tax.Set{
 				&tax.Combo{
-					Category: "VAT",
+					Category: tax.CategoryVAT,
 					Ext:      tax.Extensions{tbai.ExtKeyExempt: "RL"},
 				},
 			},
@@ -260,8 +260,8 @@ func TestDesgloseConversion(t *testing.T) {
 			Quantity: num.MakeAmount(100, 0),
 			Item:     &org.Item{Name: "A", Price: num.NewAmount(10, 0)},
 			Taxes: tax.Set{
-				&tax.Combo{Category: "VAT", Rate: "standard"},
-				&tax.Combo{Category: "VAT", Rate: "reduced"},
+				&tax.Combo{Category: tax.CategoryVAT, Rate: "standard"},
+				&tax.Combo{Category: tax.CategoryVAT, Rate: "reduced"},
 			},
 		}}
 		_ = goblInvoice.Calculate()
@@ -306,7 +306,7 @@ func TestDesgloseConversion(t *testing.T) {
 			Quantity: num.MakeAmount(100, 0),
 			Item:     &org.Item{Name: "A", Price: num.NewAmount(10, 0)},
 			Taxes: tax.Set{
-				&tax.Combo{Category: "VAT", Rate: "standard+eqs"},
+				&tax.Combo{Category: tax.CategoryVAT, Rate: "standard+eqs"},
 			},
 		}}
 		_ = goblInvoice.Calculate()
@@ -326,13 +326,13 @@ func TestDesgloseConversion(t *testing.T) {
 				Index:    1,
 				Quantity: num.MakeAmount(1, 0),
 				Item: &org.Item{
-					Key:   "services",
+					Key:   org.ItemKeyServices,
 					Name:  "A",
 					Price: num.NewAmount(10, 0),
 				},
 				Taxes: tax.Set{
 					&tax.Combo{
-						Category: "VAT",
+						Category: tax.CategoryVAT,
 						Rate:     "standard",
 					},
 				},
@@ -341,13 +341,13 @@ func TestDesgloseConversion(t *testing.T) {
 				Index:    2,
 				Quantity: num.MakeAmount(100, 0),
 				Item: &org.Item{
-					Key:   "goods",
+					Key:   org.ItemKeyGoods,
 					Name:  "A",
 					Price: num.NewAmount(10, 0),
 				},
 				Taxes: tax.Set{
 					&tax.Combo{
-						Category: "VAT",
+						Category: tax.CategoryVAT,
 						Rate:     "general",
 						Ext:      tax.Extensions{tbai.ExtKeyProduct: "resale"},
 					},
@@ -440,7 +440,7 @@ func TestDesgloseConversion(t *testing.T) {
 			Index:    1,
 			Quantity: num.MakeAmount(100, 0),
 			Item:     &org.Item{Name: "A", Price: num.NewAmount(10, 0)},
-			Taxes:    tax.Set{&tax.Combo{Category: "VAT", Rate: "standard"}},
+			Taxes:    tax.Set{&tax.Combo{Category: tax.CategoryVAT, Rate: "standard"}},
 		}}
 		_ = goblInvoice.Calculate()
 
@@ -458,7 +458,7 @@ func TestDesgloseConversion(t *testing.T) {
 			Index:    1,
 			Quantity: num.MakeAmount(100, 0),
 			Item:     &org.Item{Name: "A", Price: num.NewAmount(10, 0)},
-			Taxes:    tax.Set{&tax.Combo{Category: "VAT", Rate: "standard"}},
+			Taxes:    tax.Set{&tax.Combo{Category: tax.CategoryVAT, Rate: "standard"}},
 		}}
 		_ = goblInvoice.Calculate()
 

--- a/convert/doc_test.go
+++ b/convert/doc_test.go
@@ -101,7 +101,7 @@ func TestInvoiceConversion(t *testing.T) {
 		goblInvoice.Customer.TaxID = nil
 		goblInvoice.Customer.Identities = []*org.Identity{
 			{
-				Key:  "passport",
+				Key:  org.IdentityKeyPassport,
 				Code: "PP123456S",
 			},
 		}
@@ -111,6 +111,35 @@ func TestInvoiceConversion(t *testing.T) {
 		assert.Equal(t, "03", dest.IDOtro.IDType)
 		assert.Equal(t, "PP123456S", dest.IDOtro.ID)
 		assert.Empty(t, dest.IDOtro.CodigoPais)
+	})
+
+	t.Run("should use identities when Spanish customer has tax ID without code", func(t *testing.T) {
+		goblInvoice := test.LoadInvoice("sample-invoice.json")
+		goblInvoice.Customer.TaxID = &tax.Identity{Country: "ES"}
+		goblInvoice.Customer.Identities = []*org.Identity{
+			{Key: org.IdentityKeyPassport, Code: "PP123456S"},
+		}
+		invoice, _ := convert.NewTicketBAI(goblInvoice, ts, role, convert.ZoneBI)
+
+		dest := invoice.Sujetos.Destinatarios.IDDestinatario[0]
+		assert.Empty(t, dest.NIF)
+		assert.Equal(t, "03", dest.IDOtro.IDType)
+		assert.Equal(t, "PP123456S", dest.IDOtro.ID)
+		assert.Equal(t, "ES", dest.IDOtro.CodigoPais)
+	})
+
+	t.Run("should use identity country as CodigoPais when no tax ID", func(t *testing.T) {
+		goblInvoice := test.LoadInvoice("sample-invoice.json")
+		goblInvoice.Customer.TaxID = nil
+		goblInvoice.Customer.Identities = []*org.Identity{
+			{Country: "ES", Key: org.IdentityKeyPassport, Code: "PP123456S"},
+		}
+		invoice, _ := convert.NewTicketBAI(goblInvoice, ts, role, convert.ZoneBI)
+
+		dest := invoice.Sujetos.Destinatarios.IDDestinatario[0]
+		assert.Equal(t, "03", dest.IDOtro.IDType)
+		assert.Equal(t, "PP123456S", dest.IDOtro.ID)
+		assert.Equal(t, "ES", dest.IDOtro.CodigoPais)
 	})
 
 	t.Run("should allow having no customer (useful for simplied invoices)", func(t *testing.T) {

--- a/convert/invoice.go
+++ b/convert/invoice.go
@@ -149,7 +149,7 @@ func newRetencionSoportada(inv *bill.Invoice) string {
 func newClaves(inv *bill.Invoice) []IDClave {
 	claves := []IDClave{}
 
-	if inv.Customer != nil && partyTaxCountry(inv.Customer) != "ES" {
+	if inv.Customer != nil && partyCountry(inv.Customer) != "ES" {
 		claves = append(claves, IDClave{
 			ClaveRegimenIvaOpTrascendencia: "02",
 		})

--- a/convert/invoice_test.go
+++ b/convert/invoice_test.go
@@ -92,7 +92,7 @@ func TestFacturaConversion(t *testing.T) {
 			Quantity:  num.MakeAmount(100, 0),
 			Item:      &org.Item{Name: "A", Price: num.NewAmount(11, 0)},
 			Discounts: []*bill.LineDiscount{DiscountOf(100)},
-			Taxes:     tax.Set{&tax.Combo{Category: "VAT", Rate: "standard"}},
+			Taxes:     tax.Set{&tax.Combo{Category: tax.CategoryVAT, Rate: "standard"}},
 		}}
 		_ = goblInvoice.Calculate()
 
@@ -109,8 +109,8 @@ func TestFacturaConversion(t *testing.T) {
 			Quantity: num.MakeAmount(100, 0),
 			Item:     &org.Item{Name: "A", Price: num.NewAmount(10, 0)},
 			Taxes: tax.Set{
-				&tax.Combo{Category: "VAT", Rate: "standard"},
-				&tax.Combo{Category: "IRPF", Rate: "pro"},
+				&tax.Combo{Category: tax.CategoryVAT, Rate: "standard"},
+				&tax.Combo{Category: es.TaxCategoryIRPF, Rate: "pro"},
 			},
 		}}
 		_ = goblInvoice.Calculate()
@@ -128,8 +128,8 @@ func TestFacturaConversion(t *testing.T) {
 			Quantity: num.MakeAmount(100, 0),
 			Item:     &org.Item{Name: "A", Price: num.NewAmount(10, 0)},
 			Taxes: tax.Set{
-				&tax.Combo{Category: "VAT", Rate: "standard"},
-				&tax.Combo{Category: "IRPF", Rate: "pro"},
+				&tax.Combo{Category: tax.CategoryVAT, Rate: "standard"},
+				&tax.Combo{Category: es.TaxCategoryIRPF, Rate: "pro"},
 			},
 		}}
 		_ = goblInvoice.Calculate()
@@ -147,7 +147,7 @@ func TestFacturaConversion(t *testing.T) {
 			Quantity: num.MakeAmount(100, 0),
 			Item:     &org.Item{Name: "A", Price: num.NewAmount(10, 0)},
 			Taxes: tax.Set{
-				&tax.Combo{Category: "VAT", Rate: "standard"},
+				&tax.Combo{Category: tax.CategoryVAT, Rate: "standard"},
 			},
 		}}
 		_ = goblInvoice.Calculate()
@@ -174,13 +174,13 @@ func TestFacturaConversion(t *testing.T) {
 			Index:    1,
 			Quantity: num.MakeAmount(100, 0),
 			Item: &org.Item{
-				Key:   "goods",
+				Key:   org.ItemKeyGoods,
 				Name:  "A",
 				Price: num.NewAmount(10, 0),
 			},
 			Taxes: tax.Set{
 				&tax.Combo{
-					Category: "VAT",
+					Category: tax.CategoryVAT,
 					Rate:     "standard",
 					Ext:      tax.Extensions{tbai.ExtKeyProduct: "resale"},
 				},

--- a/convert/lines_test.go
+++ b/convert/lines_test.go
@@ -25,7 +25,7 @@ func TestLines(t *testing.T) {
 			Index:    1,
 			Quantity: num.MakeAmount(100, 0),
 			Item:     &org.Item{Name: "A", Price: num.NewAmount(10, 0)},
-			Taxes:    tax.Set{&tax.Combo{Category: "VAT", Rate: "standard"}},
+			Taxes:    tax.Set{&tax.Combo{Category: tax.CategoryVAT, Rate: "standard"}},
 		}}
 		_ = goblInvoice.Calculate()
 
@@ -46,7 +46,7 @@ func TestLines(t *testing.T) {
 			Quantity:  num.MakeAmount(100, 0),
 			Item:      &org.Item{Name: "A", Price: num.NewAmount(11, 0)},
 			Discounts: []*bill.LineDiscount{DiscountOf(100)},
-			Taxes:     tax.Set{&tax.Combo{Category: "VAT", Rate: "standard"}},
+			Taxes:     tax.Set{&tax.Combo{Category: tax.CategoryVAT, Rate: "standard"}},
 		}}
 		_ = goblInvoice.Calculate()
 
@@ -65,7 +65,7 @@ func TestLines(t *testing.T) {
 			Index:    1,
 			Quantity: num.MakeAmount(10, 0),
 			Item:     &org.Item{Name: "A", Price: num.NewAmount(121, 0)},
-			Taxes:    tax.Set{&tax.Combo{Category: "VAT", Rate: "standard"}},
+			Taxes:    tax.Set{&tax.Combo{Category: tax.CategoryVAT, Rate: "standard"}},
 		}}
 		require.NoError(t, inv.Calculate())
 		require.NoError(t, inv.RemoveIncludedTaxes())

--- a/convert/parties.go
+++ b/convert/parties.go
@@ -65,7 +65,7 @@ func newDestinatario(party *org.Party) *IDDestinatario {
 		ApellidosNombreRazonSocial: party.Name,
 	}
 
-	if partyTaxCountry(party) == "ES" {
+	if party.TaxID != nil && party.TaxID.Country == "ES" && party.TaxID.Code != "" {
 		d.NIF = party.TaxID.Code.String()
 	} else {
 		d.IDOtro = otherIdentity(party)
@@ -96,6 +96,9 @@ func otherIdentity(party *org.Party) *IDOtro {
 	}
 
 	for _, id := range party.Identities {
+		if id == nil || id.Code == "" {
+			continue
+		}
 		it, ok := idTypeCodeMap[id.Key]
 		if !ok {
 			continue
@@ -103,15 +106,26 @@ func otherIdentity(party *org.Party) *IDOtro {
 
 		oid.IDType = it
 		oid.ID = id.Code.String()
+		if id.Country != "" {
+			oid.CodigoPais = id.Country.String()
+		}
 		return oid
 	}
 
 	return nil
 }
 
-func partyTaxCountry(party *org.Party) l10n.TaxCountryCode {
-	if party != nil && party.TaxID != nil {
+func partyCountry(party *org.Party) l10n.TaxCountryCode {
+	if party == nil {
+		return ""
+	}
+	if party.TaxID != nil && party.TaxID.Country != "" {
 		return party.TaxID.Country
+	}
+	for _, id := range party.Identities {
+		if id != nil && id.Country != "" {
+			return l10n.TaxCountryCode(id.Country)
+		}
 	}
 	return ""
 }


### PR DESCRIPTION
- Support Spanish customers to issue simplified invoices using passport
- Map identities country that was not mapped
- Use identities country to get IDType
- Adapt to new linter