### PR TITLE
Fix goreleaser release target after repo rename

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod download
@@ -14,16 +16,17 @@ builds:
 
 archives:
   - id: gobl.ticketbai
-    builds:
+    ids:
       - gobl.ticketbai
-    format: tar.gz
+    formats:
+      - tar.gz
     name_template: "gobl.ticketbai_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     wrap_in_directory: true
 
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ .Tag }}"
+  version_template: "{{ .Tag }}"
 changelog:
   sort: asc
   filters:
@@ -33,5 +36,5 @@ changelog:
 release:
   github:
     owner: invopop
-    name: gobl.ticketbai
+    name: gobl.es.ticketbai
   prerelease: auto


### PR DESCRIPTION
## Problem

The `v0.48.0` release failed: every asset upload returned `307` from `uploads.github.com` (`location <nil>`), so no binaries/checksums were attached.

Root cause: the repo was renamed `invopop/gobl.ticketbai` → `invopop/gobl.es.ticketbai`, but `.goreleaser.yml` hard-coded the **old** name in `release.github.name`. goreleaser created the release on the new (redirected) repo but built upload URLs from the old name → GitHub 307-redirects the upload POST, which the go-github client won't follow.

## Fix

- Point `release.github.name` at `gobl.es.ticketbai`.
- Migrate the config to the goreleaser **v2** schema, clearing the deprecation/`version: 0` warnings from the log:
  - add `version: 2`
  - `archives.format` → `archives.formats: [tar.gz]`
  - `archives.builds` → `archives.ids`
  - `snapshot.name_template` → `snapshot.version_template`

Validated locally with `goreleaser check` (1 file validated, no warnings).

Note: the Go module path is intentionally left as `github.com/invopop/gobl.ticketbai` (renaming it is a separate breaking change for importers; the GitHub redirect keeps `go get` working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)