### PR TITLE
Fix cancellation error handling and detect already cancelled invoices

### DIFF
--- a/internal/gateways/araba.go
+++ b/internal/gateways/araba.go
@@ -86,7 +86,7 @@ func (c *ArabaConn) Cancel(ctx context.Context, _ *bill.Invoice, doc *convert.An
 	if err != nil {
 		return fmt.Errorf("generating payload: %w", err)
 	}
-	return c.post(ctx, arabaCancelPath, payload)
+	return asCancelDuplicate(c.post(ctx, arabaCancelPath, payload))
 }
 
 func (c *ArabaConn) post(ctx context.Context, path string, payload []byte) error {

--- a/internal/gateways/gateways.go
+++ b/internal/gateways/gateways.go
@@ -34,6 +34,26 @@ var (
 	ErrDuplicate  = newError("duplicate")
 )
 
+// Validation codes from the common TicketBAI specification, shared by the
+// Araba and Gipuzkoa gateways.
+const (
+	// codeAlreadyCancelled is returned when the invoice being cancelled has
+	// already been cancelled previously: "El fichero de alta ya ha sido
+	// anulado previamente".
+	codeAlreadyCancelled = "019"
+)
+
+// asCancelDuplicate converts the validation responses that imply the document
+// has already been cancelled into an ErrDuplicate, so that repeating a cancel
+// request can be handled as a no-op upstream.
+func asCancelDuplicate(err error) error {
+	var e *Error
+	if errors.As(err, &e) && e.Code() == codeAlreadyCancelled {
+		return ErrDuplicate.withCode(e.Code()).withMessage(e.Message())
+	}
+	return err
+}
+
 // Error allows for structured responses from the gateway to be able to
 // response codes and messages.
 type Error struct {

--- a/internal/gateways/gateways_test.go
+++ b/internal/gateways/gateways_test.go
@@ -1,0 +1,109 @@
+package gateways
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/invopop/gobl.ticketbai/convert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const cancelRejectedResponse = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:TicketBaiResponse xmlns:ns2="urn:ticketbai:anulacion">
+	<Salida>
+		<FechaRecepcion>05-08-2026 09:20:36</FechaRecepcion>
+		<Estado>01</Estado>
+		<Descripcion>Rechazado</Descripcion>
+		<ResultadosValidacion>
+			<Codigo>%s</Codigo>
+			<Descripcion>%s</Descripcion>
+		</ResultadosValidacion>
+	</Salida>
+</ns2:TicketBaiResponse>`
+
+func TestAsCancelDuplicate(t *testing.T) {
+	t.Run("already cancelled becomes a duplicate", func(t *testing.T) {
+		err := asCancelDuplicate(
+			ErrValidation.
+				withCode("019").
+				withMessage("El fichero de alta ya ha sido anulado previamente"),
+		)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrDuplicate)
+		assert.NotErrorIs(t, err, ErrValidation)
+
+		var e *Error
+		require.ErrorAs(t, err, &e)
+		assert.Equal(t, "019", e.Code())
+		assert.Equal(t, "El fichero de alta ya ha sido anulado previamente", e.Message())
+	})
+
+	t.Run("other validation errors are untouched", func(t *testing.T) {
+		err := asCancelDuplicate(ErrValidation.withCode("005").withMessage("nope"))
+		assert.ErrorIs(t, err, ErrValidation)
+		assert.NotErrorIs(t, err, ErrDuplicate)
+	})
+
+	t.Run("nil stays nil", func(t *testing.T) {
+		assert.NoError(t, asCancelDuplicate(nil))
+	})
+
+	t.Run("unknown errors are untouched", func(t *testing.T) {
+		cause := errors.New("boom")
+		assert.Equal(t, cause, asCancelDuplicate(cause))
+	})
+}
+
+// TestRegionalCancelDuplicate ensures the regional gateways that share the
+// common TicketBAI response format identify an already cancelled invoice.
+func TestRegionalCancelDuplicate(t *testing.T) {
+	conns := map[string]func(*tls.Config, string) Connection{
+		"araba": func(tlsConf *tls.Config, url string) Connection {
+			c := newAraba(EnvironmentSandbox, tlsConf)
+			c.client.SetBaseURL(url)
+			return c
+		},
+		"gipuzkoa": func(tlsConf *tls.Config, url string) Connection {
+			c := newGipuzkoa(EnvironmentSandbox, tlsConf)
+			c.client.SetBaseURL(url)
+			return c
+		},
+	}
+
+	responses := []struct {
+		code    string
+		message string
+		target  error
+	}{
+		{"019", "El fichero de alta ya ha sido anulado previamente", ErrDuplicate},
+		{"005", "El fichero de alta no existe", ErrValidation},
+	}
+
+	for name, newConn := range conns {
+		for _, row := range responses {
+			t.Run(name+"/"+row.code, func(t *testing.T) {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/xml")
+					fmt.Fprintf(w, cancelRejectedResponse, row.code, row.message)
+				}))
+				defer srv.Close()
+
+				conn := newConn(new(tls.Config), srv.URL)
+				err := conn.Cancel(context.Background(), nil, new(convert.AnulaTicketBAI))
+				require.Error(t, err)
+				assert.ErrorIs(t, err, row.target)
+
+				var e *Error
+				require.ErrorAs(t, err, &e)
+				assert.Equal(t, row.code, e.Code())
+				assert.Equal(t, row.message, e.Message())
+			})
+		}
+	}
+}

--- a/internal/gateways/gipuzkoa.go
+++ b/internal/gateways/gipuzkoa.go
@@ -87,7 +87,7 @@ func (c *GipuzkoaConn) Cancel(ctx context.Context, _ *bill.Invoice, doc *convert
 	if err != nil {
 		return fmt.Errorf("generating payload: %w", err)
 	}
-	return c.post(ctx, gipuzkoaCancelPath, payload)
+	return asCancelDuplicate(c.post(ctx, gipuzkoaCancelPath, payload))
 }
 
 func (c *GipuzkoaConn) post(ctx context.Context, path string, payload []byte) error {

--- a/test_connection.go
+++ b/test_connection.go
@@ -12,6 +12,11 @@ import (
 type TestConnection struct {
 	postCalled   bool
 	cancelCalled bool
+
+	// PostError and CancelError, when set, are returned by the corresponding
+	// method so that error handling can be exercised by tests.
+	PostError   error
+	CancelError error
 }
 
 var _ gateways.Connection = (*TestConnection)(nil)
@@ -19,11 +24,11 @@ var _ gateways.Connection = (*TestConnection)(nil)
 // Post mocks the Post method of the Connection interface
 func (tc *TestConnection) Post(_ context.Context, _ *bill.Invoice, _ *convert.TicketBAI) error {
 	tc.postCalled = true
-	return nil
+	return tc.PostError
 }
 
 // Cancel mocks the Cancel method of the Connection interface
 func (tc *TestConnection) Cancel(_ context.Context, _ *bill.Invoice, _ *convert.AnulaTicketBAI) error {
 	tc.cancelCalled = true
-	return nil
+	return tc.CancelError
 }

--- a/ticketbai.go
+++ b/ticketbai.go
@@ -157,7 +157,10 @@ func (c *Client) Cancel(ctx context.Context, env *gobl.Envelope, d *convert.Anul
 	if !ok {
 		return ErrValidation.withMessage("only invoices are supported")
 	}
-	return c.gw.Cancel(ctx, inv, d)
+	if err := c.gw.Cancel(ctx, inv, d); err != nil {
+		return newErrorFrom(err)
+	}
+	return nil
 }
 
 // ParseDocument will parse the XML data into a TicketBAI document.


### PR DESCRIPTION
## Problem

Repeating a `ticketbai.cancel` request in gov-es produced a hard error that retried forever:

```
cancelling document (validation: 019: El fichero de alta ya ha sido anulado previamente)
```

Two defects on this side:

1. **`Client.Cancel` never wrapped its error.** `Post` does `return newErrorFrom(err)`; `Cancel` did a bare `return c.gw.Cancel(...)`, leaking the internal `*gateways.Error`. Since `(*gateways.Error).Is` only compares against its own type and the cause is nil, `errors.Is(err, ticketbai.ErrValidation)` returned **false** for every cancellation failure — callers could not classify a cancel error at all.

2. **No way to detect an already cancelled invoice.** The gateways reject the second attempt with validation code `019`, indistinguishable from any other rejection.

## Changes

- `Client.Cancel` now wraps via `newErrorFrom`, matching `Post`, so `ErrValidation` / `ErrDuplicate` / `ErrConnection` are detectable by callers.
- New `asCancelDuplicate` helper maps validation code `019` on the cancel path to `ErrDuplicate`, wired into the Araba and Gipuzkoa `Cancel` methods (they share the common TicketBAI response format).
- `TestConnection` gained `PostError` / `CancelError` fields so downstream error handling can be exercised in tests.

## Not covered

Bizkaia. `EBizkaiaConn.Cancel` passes `nil` as the response struct and the `ebizkaia` package has no `AnulacionRespuesta` type, so there is no per-record error code to inspect, and I have no confirmed LROE code for "already cancelled" (`B4_2000003` is the *alta* duplicate). Fix 1 still applies, so Bizkaia rejections now classify as validation errors rather than being opaque — but they will not map to `ErrDuplicate`. Worth a follow-up once a real Bizkaia double-cancel response can be captured.

## Testing

New `internal/gateways/gateways_test.go`: unit tests for the mapping, plus httptest-backed tests driving both regional `Cancel` implementations with real rejection XML (codes `019` → duplicate, `005` → validation). Full suite passes.

The companion gov-es change is in invopop/gov-es#33 and needs a release of this repo first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)